### PR TITLE
Improve Makefile & fix interpreter version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,21 +2,23 @@
     gpg-check release-patch release-minor release-major release-tag release-tag-dry \
     release-check release-flow release-clean release-build release-info release-status cz-commit cz-changelog cz-bump
 
+PIP=pip
+
 # 🔧 Install package (runtime only)
 install:
-	pip install .
+	$(PIP) install .
 
 # 🔧 Install package with dev extras (pytest, mypy, flake8, black, isort, etc.)
 install-dev:
-	pip install .[dev]
+	$(PIP) install .[dev]
 
 #  🔧 Install package with PDF extras (weasyprint)
 install-pdf:
-	pip install .[pdf]
+	$(PIP) install .[pdf]
 
 # 🔧 Uninstall package
 uninstall:
-	pip uninstall -y dns-benchmark-tool \
+	$(PIP) uninstall -y dns-benchmark-tool \
 	dnspython pandas aiohttp click pyfiglet colorama Jinja2 openpyxl pyyaml tqdm matplotlib \
     mypy black flake8 autopep8 pytest coverage isort
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "Joseph Oseh Frank", email = "frank@osehfrank.com" }
 ]
 license = { text = "MIT" }
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<=3.14.3"
 keywords = ["DNS", "benchmark", "performance", "DNSSEC", "DoH", "DoT", "networking", "latency", "resolver", "metrics"]
 
 dependencies = [


### PR DESCRIPTION
Hi, i tryied to install for my distribution via pip (`pipx` on Archlinux) but for some reason the version installed doesn't have the latest changes so `dns-benchmark benchmark --resolvers='Cloudflare,Google,Quad9' --domains='ping-eu.ds.on.epicgames.com'` say that there is no file.

so i cloned the repo and notice 2 possible improvements:

1) i typed `make`, thats throw me an error bc. i should use `pipx` instead of `pip` on my distro or i should create a virtual env, thus i defined the `$(PIP)` variable make easier to replace in future if needed (however tests doesn't work well without using a virtualenv because of the following command `python -m dns_benchmark.cli --help` in test_cli_command[cmd_19] but the command seems fine).

2) the interpreter requirement version in `pyproject.toml` are `>=3.9,<3.13` and refuse to build, but i changed the upper bound to `3.14.3` (which is my current version) and seems that  works fine too. However i only tested my use-case and i don't know if is possible change the python version without breaking the code, but all tests passes. 

Probably an upper bound on python version isn't required at all at least for now (?)

### Tests
i runned tests with `make test` everything seems fine with python 3.14.3

```
python -m venv venv
source venv/bin/activate
make install-dev
make install-pdf
make test
```
<img width="1920" height="1080" alt="immagine" src="https://github.com/user-attachments/assets/1157f340-449a-442f-9237-ce41f8a267db" />