### PR TITLE
docs(deprecation): freeze dns-benchmark-tool at 1.1.0, migrate to net…

### DIFF
--- a/README-pypi.md
+++ b/README-pypi.md
@@ -1,5 +1,11 @@
 <div align="center">
 
+> ⚠️ **deprecated.** this package is no longer maintained.
+> migrate to: `pip install net-benchmark`
+> https://github.com/net-benchmark/net-benchmark
+
+---
+
 # DNS Benchmark Tool
 
 **Fast, comprehensive DNS performance testing**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 <div align="center">
 
+> ⚠️ **this project has moved and is no longer maintained.**
+> install the successor: `pip install net-benchmark`
+> repository: https://github.com/net-benchmark/net-benchmark
+> all existing commands and flags remain fully compatible.
+
+---
+
 # DNS Benchmark Tool
 
 ## Part of [BuildTools](https://buildtools.net) - Network Performance Suite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "dns-benchmark-tool"
 version = "1.0.0"
-description = "Fast, comprehensive DNS performance testing with DNSSEC validation, DoH/DoT support, and enterprise features."
+description = "deprecated — migrate to net-benchmark. see https://github.com/net-benchmark/net-benchmark"
 readme = { file = "README-pypi.md", content-type = "text/markdown" }
 authors = [
     { name = "Joseph Oseh Frank", email = "frank@osehfrank.com" }
@@ -15,6 +15,7 @@ requires-python = ">=3.9,<3.13"
 keywords = ["DNS", "benchmark", "performance", "DNSSEC", "DoH", "DoT", "networking", "latency", "resolver", "metrics"]
 
 dependencies = [
+    "net-benchmark",
     "dnspython>=2.7,<3.0",       
     "pandas>=2.0,<3.0",          
     "aiohttp>=3.8,<4.0",         
@@ -48,11 +49,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/frankovo/dns-benchmark-tool"
-Documentation = "https://github.com/frankovo/dns-benchmark-tool#readme"
-Source = "https://github.com/frankovo/dns-benchmark-tool"
-Tracker = "https://github.com/frankovo/dns-benchmark-tool/issues"
-Changelog = "https://github.com/frankovo/dns-benchmark-tool/blob/main/CHANGELOG.md"
+"Homepage" = "https://github.com/net-benchmark/net-benchmark"
+"Migrated To" = "https://github.com/net-benchmark/net-benchmark"
+"PyPI" = "https://pypi.org/project/net-benchmark"
 
 [project.optional-dependencies]
 pdf = ["weasyprint>=66.0,<67.0"]

--- a/src/dns_benchmark/__init__.py
+++ b/src/dns_benchmark/__init__.py
@@ -1,1 +1,11 @@
+import warnings
+
 __version__ = "1.0.0"
+
+warnings.warn(
+    "dns-benchmark-tool is deprecated and no longer maintained. "
+    "migrate to: pip install net-benchmark — "
+    "https://github.com/net-benchmark/net-benchmark",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/src/dns_benchmark/cli.py
+++ b/src/dns_benchmark/cli.py
@@ -106,29 +106,20 @@ def _resolve_protocol_and_doh_urls(
 @click.version_option(__version__, prog_name="DNS Benchmark Tool")
 def cli() -> None:
     """
-    Buildtools - DNS Benchmark Tool - Measure and compare DNS resolver performance
+    deprecated — migrate to net-benchmark. https://github.com/net-benchmark/net-benchmark
     CLI entry point.
     """
     # Allow suppression of banner for CI/CD
     if not os.environ.get("NO_BANNER"):
         ascii_art = pyfiglet.figlet_format("DNS Benchmark")
         print(Fore.GREEN + ascii_art + Style.RESET_ALL)
+        print(Fore.YELLOW + "⚠️  dns-benchmark-tool is deprecated." + Style.RESET_ALL)
+        print(Fore.CYAN + "migrate to: pip install net-benchmark" + Style.RESET_ALL)
         print(
             Fore.CYAN
-            + "Part of BuildTools - Network Performance Suite"
+            + "https://github.com/net-benchmark/net-benchmark"
             + Style.RESET_ALL
         )
-        print(
-            Fore.YELLOW
-            + "🌐 buildtools.net | ⭐ 358 stars | 📦 1,400+ downloads"
-            + Style.RESET_ALL
-        )
-        print(
-            Fore.GREEN
-            + "🚀 Web dashboard now live — DNS benchmark + monitoring at buildtools.net"
-            + Style.RESET_ALL
-        )
-        print(Fore.BLUE + "💡 Multi-region testing coming Q3 2026" + Style.RESET_ALL)
         print()
 
 


### PR DESCRIPTION
…-benchmark

- add deprecationwarning on import pointing to net-benchmark
- add net-benchmark as dependency so pip install pulls new package
- update readme with migration notice at top
- update pyproject.toml with migrated-to url
- update cli.py with deprecation warning
- no further features will be added to this repo